### PR TITLE
Added swift breakpoint support

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
                         "objective-c",
                         "pascal",
                         "rust",
-                        "lldb.disassembly"
+                        "lldb.disassembly",
+                        "swift"
                     ]
                 },
                 "runtime": "node",


### PR DESCRIPTION
I've been using this extension to debug swift code, but I couldn't add breakpoints without using the terminal. This lets me add breakpoints.