### PR TITLE
Fix initial process state for custom launch.

### DIFF
--- a/adapter/debugsession.py
+++ b/adapter/debugsession.py
@@ -461,7 +461,8 @@ class DebugSession:
         except Exception as e:
             self.send_response(self.launch_args['response'], e)
         # LLDB doesn't seem to automatically generate a stop event for stop_on_entry
-        if self.process is not None and self.launch_args.get('stopOnEntry') and self.process.is_stopped:
+        check_for_stop = self.launch_args.get('stopOnEntry') or self.launch_args.get('request') == 'custom'
+        if self.process is not None and check_for_stop and self.process.is_stopped:
             self.notify_target_stopped(None)
 
     def DEBUG_pause(self, args):


### PR DESCRIPTION
Disregard 'stopOnEntry' for custom configurations and read the actual
process status. Without this custom configurations are left in
incosistent state after launch: vscode thinks they are running and so
must be manually started using the debug console.