### PR TITLE
Fix the link to LLDB installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Rust debugging:
 
 # Prerequisites
 - Visual Studio Code 1.15.0.
-- LLDB with Python scripting support on system PATH. ([Installing LLDB](#installing-lldb))
+- LLDB with Python scripting support on system PATH. ([Installing LLDB](https://github.com/vadimcn/vscode-lldb/wiki/Installing-LLDB))
 
 # Quick Start
 Here's a minimal debug configuration to get you started:


### PR DESCRIPTION
Fix the link to LLDB installation instructions in "Prerequisites"
section to correctly lead to the relevant wiki page. Current link
refers to a non-existing "Installing LLDB" section in README.md.