### PR TITLE
fix UnicodeDecodeError when non-ascii environment variable exists

### DIFF
--- a/adapter/debugsession.py
+++ b/adapter/debugsession.py
@@ -119,7 +119,7 @@ class DebugSession:
             target_args = [to_lldb_str(arg) for arg in target_args]
         # environment
         env = args.get('env', None)
-        envp = [to_lldb_str('%s=%s' % pair) for pair in os.environ.items()]
+        envp = [str('%s=%s' % pair) for pair in os.environ.items()]
         if env is not None: # Convert dict to a list of 'key=value' strings
             envp = envp + ([to_lldb_str('%s=%s' % pair) for pair in env.items()])
         # stdio


### PR DESCRIPTION
Fix #80 by simply replace `to_lldb_str` to `str`.