### PR TITLE
Fix crash on stack enumeration

### DIFF
--- a/adapter/debugsession.py
+++ b/adapter/debugsession.py
@@ -647,11 +647,12 @@ class DebugSession:
                 le = frame.GetLineEntry()
                 if le.IsValid():
                     fs = le.GetFileSpec()
-                    full_path = self.map_path_to_local(fs.fullpath)
-                    if full_path:
-                        stack_frame['source'] = { 'name': fs.basename, 'path': full_path }
-                        stack_frame['line'] = le.GetLine()
-                        stack_frame['column'] = le.GetColumn()
+                    if fs.fullpath is not None:
+                        full_path = self.map_path_to_local(fs.fullpath)
+                        if full_path:
+                            stack_frame['source'] = { 'name': fs.basename, 'path': full_path }
+                            stack_frame['line'] = le.GetLine()
+                            stack_frame['column'] = le.GetColumn()
             else:
                 pc_addr = frame.GetPCAddress()
                 dasm = self.disassembly.get_by_address(pc_addr)


### PR DESCRIPTION
The extension crashes when enumerating the stack at some breakpoints. Change is simple fix/workaround that resolves the issue.

Below is debug console output that happens when issue occurs. fe.IsValid() is true but prints to ":0".

```
Internal debugger error:
Traceback (most recent call last):
  File "/root/.vscode/extensions/vadimcn.vscode-lldb-dev/adapter/debugsession.py", line 1057, in handle_message
    result = handler(args)
  File "/root/.vscode/extensions/vadimcn.vscode-lldb-dev/adapter/debugsession.py", line 650, in DEBUG_stackTrace
    full_path = self.map_path_to_local(fs.fullpath)
  File "/root/.vscode/extensions/vadimcn.vscode-lldb-dev/adapter/debugsession.py", line 1248, in map_path_to_local
    path = os.path.normpath(path)
  File "/usr/lib/python2.7/posixpath.py", line 335, in normpath
    initial_slashes = path.startswith('/')
AttributeError: 'NoneType' object has no attribute 'startswith'
```