### PR TITLE
Fix null-frame issue

### DIFF
--- a/adapter/debugsession.py
+++ b/adapter/debugsession.py
@@ -707,7 +707,7 @@ class DebugSession:
         container, container_vpath = container_info
         container_name = None
         variables = collections.OrderedDict()
-        if isinstance(container, LocalsScope):
+        if isinstance(container, LocalsScope) and container.frame is not None:
             # args, locals, statics, in_scope_only
             vars_iter = SBValueListIter(container.frame.GetVariables(True, True, False, True))
             # Check if we have a return value from the last called function (usually after StepOut).


### PR DESCRIPTION

Simple check to avoid the following crash:

Internal debugger error:
Traceback (most recent call last):
  File "/root/.vscode/extensions/vadimcn.vscode-lldb-dev/adapter/debugsession.py", line 1058, in handle_message
    result = handler(args)
  File "/root/.vscode/extensions/vadimcn.vscode-lldb-dev/adapter/debugsession.py", line 713, in DEBUG_variables
    vars_iter = SBValueListIter(container.frame.GetVariables(True, True, False, True))
AttributeError: 'NoneType' object has no attribute 'GetVariables'


