### PR TITLE
Conditionally setup SIGHUP handler if the OS supports it

### DIFF
--- a/adapter/main.py
+++ b/adapter/main.py
@@ -14,7 +14,8 @@ from . import PY2, is_string, debugger_api
 log = logging.getLogger('main')
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
-signal.signal(signal.SIGHUP, signal.SIG_DFL)
+if hasattr(signal, 'SIGHUP'):
+    signal.signal(signal.SIGHUP, signal.SIG_DFL)
 
 sys.modules['debugger'] = debugger_api
 


### PR DESCRIPTION
The recent commit 6ff46981 breaks debugging on windows because it doesn't support SIGHUP. According to the docs "Note that not all systems define the same set of signal names; only those names defined by the system are defined by this module." https://docs.python.org/3/library/signal.html