### PR TITLE
Refactor pickProcess to return string

### DIFF
--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -287,11 +287,11 @@ class Extension implements TextDocumentContentProvider, DebugConfigurationProvid
         }));
     }
 
-    async pickProcess(currentUserOnly: boolean): Promise<number> {
+    async pickProcess(currentUserOnly: boolean): Promise<string> {
         let items = util.getProcessList(currentUserOnly);
         let item = await window.showQuickPick(items);
         if (item) {
-            return item.pid;
+            return item.pid.toString();
         } else {
             throw Error('Cancelled');
         }


### PR DESCRIPTION
VSCode expects pid returned by pickProcess to be of type string. Since a number has been returned instead of string, VSCode throws error when trying to attach to a process.