### PR TITLE
To use ${command: rather than ${command.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -72,7 +72,7 @@ on some systems.  You may need to adjust system configuration to enable it.
 |**type**           |string  |Y| Set to `lldb`.
 |**request**        |string  |Y| Set to `attach`.
 |**program**        |string  |Y| Path to debuggee executable.
-|**pid**            |number  | | Process id to attach to.  **pid** may be omitted, in which case debugger will attempt to locate an already running instance of the program. You may also put `${command.pickProcess}` or `${command.pickMyProcess}` here to choose a process interactively.
+|**pid**            |number  | | Process id to attach to.  **pid** may be omitted, in which case debugger will attempt to locate an already running instance of the program. You may also put `${command:pickProcess}` or `${command:pickMyProcess}` here to choose a process interactively.
 |**stopOnEntry**    |boolean | | Whether to stop the debuggee immediately after attaching.
 |**waitFor**        |boolean | | Wait for the process to launch.
 |**initCommands**   |[string]| | LLDB commands executed upon debugger startup.


### PR DESCRIPTION
VSCode complains ${command.pickMyProcess}. It has to be ${command:pickMyProcess} and it worked in my environment.

https://www.flickr.com/photos/suztomo/43806062892/in/dateposted/

My environment: Mac OS 10.13.6. VSCode 1.21.1