### PR TITLE
Fix C/C++ boilerplate generating

### DIFF
--- a/extension/cargo.ts
+++ b/extension/cargo.ts
@@ -150,10 +150,6 @@ export async function getLaunchConfigs(folder: string): Promise<DebugConfigurati
             }
         }
     }
-    if (configs.length == 0) {
-        window.showErrorMessage(`No supported binary artifact kinds in the project. Aborting...`, { modal: true });
-        throw new Error('Cannot generate launch.json.');
-    }
     return configs;
 }
 


### PR DESCRIPTION
Lack of `Cargo.toml` should not mean not creating example `launch.json`, defined here:

https://github.com/vadimcn/vscode-lldb/blob/master/extension/extension.ts#L95-L102