### PR TITLE
Match case of existing environment variables

### DIFF
--- a/extension/adapter.ts
+++ b/extension/adapter.ts
@@ -83,9 +83,23 @@ function getAdapterParameters(config: WorkspaceConfiguration, params: Dict<any>)
 // regex pattern, or until the timeout expires.
 export function spawnDebugger(args: string[], adapterPath: string, adapterEnv: Dict<string>): cp.ChildProcess {
     let env = Object.assign({}, process.env);
+    
+    // Create object mapping from lowercased existing environment variable to their original names.
+    const envVariables = Object.keys(env).reduce((acc, key) => {
+        acc[key.toLowerCase()] = key;
+        return acc;
+    }, {});
+    
     for (let key in adapterEnv) {
-        env[key] = util.expandVariables(adapterEnv[key], (type, key) => {
-            if (type == 'env') return process.env[key];
+        // If there is an existing environment variable, potentially with a different case, use it.
+        // For example, users might write "PATH" in their settings while the system has a "Path" environment variable.
+        const envVariable = envVariables[key.toLowerCase()] || key;
+        
+        env[envVariable] = util.expandVariables(adapterEnv[key], (type, key) => {
+            if (type == 'env') {
+                const envVariable = envVariables[key.toLowerCase()] || key;
+                return process.env[envVariable];
+            }
             throw new Error('Unknown variable type ' + type);
         });
     }


### PR DESCRIPTION
Users might configure an environment variable `PATH` in their extension settings, while their system actually contains a `Path` variable. This is especially likely on Windows, where environment variables are case insensitive. In the current situation, an environment object with both `PATH` and `Path` keys is sent to `child_process.spawn`.

The change in this PR ensures a user's environment variables are matched with existing variables. If there is an existing variable (case insensitive match), its original case is used. So in the example a user's configured `PATH` would become `Path`, and the resulting `env` object only has a `Path` key.