### PR TITLE
Add thread name to call stack view

### DIFF
--- a/adapter/debugsession.py
+++ b/adapter/debugsession.py
@@ -826,7 +826,8 @@ class DebugSession:
         for thread in self.process:
             index = thread.GetIndexID()
             tid = thread.GetThreadID()
-            display = '%d: tid=%d' % (index, tid)
+            tname = thread.getName()
+            display = '%d: tid=%d tname=%s' % (index, tid, tname)
             threads.append({ 'id': tid, 'name': display })
         return { 'threads': threads }
 


### PR DESCRIPTION
It's easier to debug with human assigned names rather than random identifiers.