### PR TITLE
add valid python InstallPath registry keys

### DIFF
--- a/extension/adapter.ts
+++ b/extension/adapter.ts
@@ -64,9 +64,13 @@ export async function startNative(
     return spawnDebugAdapter(executable, args, env, workDir);
 }
 
-export const getPythonPathAsync = process.platform == 'win32' ?
-    util.readRegistry('HKLM\\Software\\Python\\PythonCore\\3.6\\InstallPath', null) :
-    null;
+export const getPythonPathAsync =
+    process.platform == 'win32' ? (
+        util.readRegistry('HKEY_LOCAL_MACHINE\\Software\\Python\\PythonCore\\3.6\\InstallPath', null) ||
+        util.readRegistry('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Python\\PythonCore\\3.6\\InstallPath', null) ||
+        util.readRegistry('HKEY_CURRENT_USER\\Software\\Python\\PythonCore\\3.6\\InstallPath', null) ||
+        util.readRegistry('HKEY_CURRENT_USER\\Software\\Wow6432Node\\Python\\PythonCore\\3.6\\InstallPath', null)
+    ) : null;
 
 export async function spawnDebugAdapter(
     executable: string,


### PR DESCRIPTION
Hey!

On Windows the extension couldn't find the correct python installation path because we tried to query the wrong registry keys in the adapter. I've added the possible correct keys.

I didn't find any contribution guidelines, so just putting it here, feel free to reformat if it looks clumsy,

Tamás