### PR TITLE
Fix cargo examples boilerplate generator

### DIFF
--- a/extension/cargo.ts
+++ b/extension/cargo.ts
@@ -48,6 +48,12 @@ export async function getProgramFromCargo(cargoConfig: CargoConfig, cwd: string)
         });
     }
 
+    if (artifacts.length == 0) {
+        output.show();
+        window.showErrorMessage('Cargo has produced no artifacts passing the filter.', { modal: true });
+        throw new Error('Cannot start debugging.');
+    }
+
     output.appendLine('Matching compilation artifacts: ');
     for (let artifact of artifacts) {
         output.appendLine(inspect(artifact));
@@ -139,9 +145,15 @@ export async function getLaunchConfigs(folder: string): Promise<DebugConfigurati
                         }
                         break;
 
+                    case 'example':
+                        addConfig(`Debug example '${target.name}'`,
+                            ['build', `--${kind}=${target.name}`], 'example');
+                        addConfig(`Debug unit tests in example '${target.name}'`,
+                            ['test', '--no-run', `--${kind}=${target.name}`], 'example');
+                        break;
+
                     case 'bin':
                     case 'test':
-                    case 'example':
                     case 'bench':
                         let prettyKind = (kind == 'bin') ? 'executable' : (kind == 'bench') ? 'benchmark' : kind;
                         addConfig(`Debug ${prettyKind} '${target.name}'`,


### PR DESCRIPTION
This PR fixes two bugs:

1. An obscure error showing up when all artifacts produced by cargo are filtered out ("Cannot read property 'fileName' of undefined"). Instead, now it explicitly says that all artifacts were filtered out.

2. Launch config boilerplate generator outputted wrong filters for cargo examples, assuming they have the 'bin' kind in `message-format=json`, while in fact they have the 'example' kind, as seen in the [manifest serialisation code](https://github.com/rust-lang/cargo/blob/4536bc91486cb68701338355b3a43db2f0b8dcb3/src/cargo/core/manifest.rs#L163).