### PR TITLE
Fix parsing of python versions

### DIFF
--- a/adapter2/loader/find_python.rs
+++ b/adapter2/loader/find_python.rs
@@ -16,7 +16,10 @@ pub fn find_python() -> Result<PathBuf, Error> {
                         let py_getversion: unsafe extern "C" fn() -> *const c_char = transmute(ptr);
                         let version = CStr::from_ptr(py_getversion());
                         if let Ok(version) = version.to_str() {
-                            if let Some(version) = version.split(" ").next() {
+                            //Python does not use a space before alpha, beta, or rc indicators.
+                            //This breaks semver parsing for these types of releases.
+                            //Split at these indicators to only parse the numeric part of the version.
+                            if let Some(version) = version.split(|c| c == ' ' || c == 'a' || c == 'b' || c == 'r' ).next() {
                                 if let Ok(version) = Version::parse(version) {
                                     if version.major == 3 && version.minor >= 3 {
                                         free_library(handle)?;


### PR DESCRIPTION
The python version scheme (https://www.python.org/dev/peps/pep-0440/)
follows the scheme [N!]N(.N)*[{a|b|rc}N][.postN][.devN], disagreeing
with the semantic versioning specification (https://semver.org/spec/v2.0.0.html)
in some important details. Notably, pre-release affixes (alpha, beta,
rc) are expressed differently. For example, the fourth release candidate
of version 1.2.3 is denoted as follows:

Python: 1.2.3rc4
SemVer: 1.2.3-rc.4

The parsing code separates the version string obtained from
Py_GetVersion by a space in order to strip off any ancillary
information. This commit extends this to strip off any alpha,
beta, or rc indicator present in the actual version.