### PR TITLE
Prepend the type name to the container summary.

### DIFF
--- a/adapter2/src/debug_session.rs
+++ b/adapter2/src/debug_session.rs
@@ -1775,7 +1775,7 @@ impl DebugSession {
     fn get_container_summary(var: &SBValue) -> String {
         const MAX_LENGTH: usize = 32;
 
-        let mut summary = String::from("{");
+        let mut summary = format!("{} {{", var.display_type_name().unwrap_or(""));
         let mut empty = true;
         for child in var.children() {
             if summary.len() > MAX_LENGTH {


### PR DESCRIPTION
For your consideration: adds a little bit of additional information to the thing that VSCode displays to users.

Before:

![image](https://user-images.githubusercontent.com/13355482/81453265-1a70be00-9157-11ea-9e6b-408f08710e29.png)


After:

![image](https://user-images.githubusercontent.com/13355482/81453073-9e767600-9156-11ea-9bac-7dee8dd2fa0a.png)

(Notice that in the latter case you don't even know what variant of the enum it is #enum
