### PR TITLE
Update value.py for python3 support

### DIFF
--- a/adapter/value.py
+++ b/adapter/value.py
@@ -1,6 +1,9 @@
 import lldb
 import operator
 
+# python3 support.
+xrange = range
+
 # A wrapper around SBValue that overloads Python operators to do the right thing (well, mostly).
 class Value(object):
     __slots__ = ['__sbvalue']


### PR DESCRIPTION
When using vscode-lldb for debugging rust, I attempted to access a slice of a vector from the debug console:

`buffer[0:100]`

It returned `name 'xrange' is not defined`

Looking in value.py I found that there's a reference to xrange, which isn't valid in python3.  This similar fix exists (but other way around) here: https://github.com/vadimcn/vscode-lldb/blob/35151d7d2de84376987e2bbc747192034e307584/formatters/rust.py#L10

This can be reproduced by entering a debugging state and trying to access a valid slice of a vector/array-like collection.

I'm all ears on how you'd like me to enhance this PR to make it acceptable.