### PR TITLE
Add breakpoint support for zig

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,6 +430,9 @@
 			},
 			{
 				"language": "swift"
+			},
+			{
+				"language": "zig"
 			}
 		],
 		"debuggers": [


### PR DESCRIPTION
Awesome extension! Have been using this as debugger for C++ and zig. This change allows setting breakpoints also for zig language.