### PR TITLE
Rust formatter: fix pretty-printing of mutable slices

### DIFF
--- a/formatters/rust.py
+++ b/formatters/rust.py
@@ -36,7 +36,7 @@ def initialize_category(debugger):
     attach_synthetic_to_type(StdVectorSynthProvider, r'^collections::vec::Vec<.+>$', True) # Before 1.20
     attach_synthetic_to_type(StdVectorSynthProvider, r'^alloc::vec::Vec<.+>$', True) # Since 1.20
 
-    attach_synthetic_to_type(SliceSynthProvider, r'^&(mut\s*)?\[.*\]$', True)
+    attach_synthetic_to_type(SliceSynthProvider, r'^&(mut[[:space:]]*)?\[.*\]$', True)
     attach_synthetic_to_type(SliceSynthProvider, r'^slice<.+>.*$', True)
 
     attach_synthetic_to_type(StdCStringSynthProvider, 'std::ffi::c_str::CString')


### PR DESCRIPTION
The supplied regular expression did not match mutable types correctly: while we are using the Python API of LLDB to register summary functions, the regular expression syntax that is supposed to be used is Posix ERE (https://llvm.org/doxygen/classllvm_1_1Regex.html) and not the one implemented by https://docs.python.org/3/library/re.html.