### PR TITLE
chore: log more error

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -436,7 +436,10 @@ impl DebugSession {
                                 RequestArguments::_symbols(args) =>
                                     self.handle_symbols(args)
                                         .map(|r| ResponseBody::_symbols(r)),
-                                _=> Err("Not implemented.".into())
+                                _=> {
+                                    info!("Received an unknown command: {}", command);
+                                    Err("Not implemented.".into())
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
An exception will be thrown in my environment，I want debug adapter can log more error to help me find the exception.

```shell
Listening on port 34871
[2021-04-22T08:26:06.496Z ERROR codelldb::debug_session] Internal debugger error: Not implemented.
[2021-04-22T08:26:06.521Z ERROR codelldb::debug_session] Internal debugger error: Not implemented.
Debug adapter exit code=0, signal=null.
```

or you can tell me how to build the extension that match my platform(debian)?