### PR TITLE
clarified docs about the location of the lldb library

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -529,8 +529,7 @@ debugger's main script context).
 # Alternate LLDB backends
 CodeLLDB can use external LLDB backends instead of the bundled one.  For example, when debugging
 Swift programs, one might want to use a custom LLDB instance that has Swift extensions built in.<br>
-In order to use alternate backend, you will need to provide location of the corresponding liblldb&#46;so/.dylib/.dll
-dynamic library via the **lldb.library** configuration setting.
+In order to use alternate backend, you will need to provide location of the corresponding `liblldb.so` (Linux)/`liblldb.dylib` (macOS)/`liblldb.dll` (Windows) dynamic library via the **lldb.library** configuration setting.
 
 Since locating liblldb is not always trivial, CodeLLDB provides the **Use Alternate Backend...** command to assist with this task.
 You will be prompted to enter the file name of the main LLDB executable, which CodeLLDB will then use to find the corresponding library.


### PR DESCRIPTION
See [here](https://github.com/vadimcn/vscode-lldb/discussions/432#discussioncomment-684418) for discussion.

Please also clarify the following in the in [wiki](https://github.com/vadimcn/vscode-lldb/wiki/Debugging-problems#debugging-swift), which I cannot change in a pull request:
> If auto-detection does not work, you can also locate liblldb...so/dylib/dll manually.

I suggest changing this line to something like
> `liblldb.so` (Linux)/`liblldb.dylib` (macOS)/`liblldb.dll` (Windows)