### PR TITLE
Start listening for process events when initialized

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -501,6 +501,7 @@ impl DebugSession {
     }
 
     fn handle_initialize(&mut self, _args: InitializeRequestArguments) -> Result<Capabilities, Error> {
+        self.event_listener.start_listening_for_event_class(&self.debugger, SBProcess::broadcaster_class_name(), !0);
         self.event_listener.start_listening_for_event_class(&self.debugger, SBThread::broadcaster_class_name(), !0);
         Ok(self.make_capabilities())
     }

--- a/debuggee/.vscode/launch.json
+++ b/debuggee/.vscode/launch.json
@@ -150,6 +150,23 @@
 			]
 		},
 		{
+			"name": "debuggee remote debugserver launch vars",
+			"type": "lldb",
+			"request": "launch",
+			"program": "${dbgconfig:targetDir}/debuggee",
+			// debugserver 127.0.0.1:1234
+			"initCommands": [
+				"platform select remote-macosx",
+				"platform settings -w /tmp"
+			],
+			"preRunCommands": [
+				"process connect connect://127.0.0.1:1234"
+			],
+			"args": [
+				"vars"
+			]
+		},
+		{
 			"name": "debuggee rr mandelbrot",
 			"type": "lldb",
 			"request": "custom",


### PR DESCRIPTION
Fixes #411.
Related: https://bugs.llvm.org/show_bug.cgi?id=50269

Turns out we need to consume process state change events emmited by lldb
in order to make it work correctly. Without this, even after successful
`process connect` command, the process state is set to "unloaded" and not
"connected". By consuming the process state change event, the process state
is set successfully set to "connected" in this case.

Also, add a launch config to test remote debugserver scenario.