### PR TITLE
Fix memory reference parsing to u64

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -2592,7 +2592,7 @@ impl DebugSession {
     }
 
     fn handle_read_memory(&mut self, args: ReadMemoryArguments) -> Result<ReadMemoryResponseBody, Error> {
-        let address = args.memory_reference.parse::<lldb::Address>()?;
+        let address = lldb::Address::from_str_radix(&args.memory_reference[ 2.. ], 16)?;
         let offset = args.offset.unwrap_or(0) as lldb::Address;
         let count = args.count as usize;
         let mut buffer = Vec::with_capacity(count);


### PR DESCRIPTION
Fixes #438 

The memory reference parsing was choking on the '0x' + hex. Change to use based parse from u64 on slice from 2nd char.

Tested with vimspector.

https://asciinema.org/a/R1zkH6pNPganpf6QBlXCdKNcj