### PR TITLE
Hide children when type summary is active.

### DIFF
--- a/adapter/deps/lldb/src/sb/sbvalue.rs
+++ b/adapter/deps/lldb/src/sb/sbvalue.rs
@@ -204,6 +204,12 @@ impl SBValue {
             unsafe { Some(CStr::from_ptr(ptr)) }
         }
     }
+    pub fn should_hide_children(&self) -> bool {
+        cpp!(unsafe [self as "SBValue*"] -> bool as "bool" {
+            auto summary = self->GetTypeSummary();
+            return summary.IsValid() && (summary.GetOptions() & lldb::eTypeOptionHideChildren) == lldb::eTypeOptionHideChildren;
+        })
+    }
     pub fn num_children(&self) -> u32 {
         cpp!(unsafe [self as "SBValue*"] -> u32 as "uint32_t" {
             return self->GetNumChildren();

--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -1869,7 +1869,10 @@ impl DebugSession {
 
     // Generate a handle for a variable.
     fn get_var_handle(&mut self, parent_handle: Option<Handle>, key: &str, var: &SBValue) -> Option<Handle> {
-        if var.num_children() > 0 || var.is_synthetic() {
+        // Hide children when type summary is present
+        if var.should_hide_children() && var.summary().is_some() {
+            None
+        } else if var.num_children() > 0 {
             Some(self.var_refs.create(parent_handle, key, Container::SBValue(var.clone())))
         } else {
             None

--- a/debuggee/cpp/debuggee.cpp
+++ b/debuggee/cpp/debuggee.cpp
@@ -145,6 +145,11 @@ void vars()
         };
     };
 
+    struct Synth
+    {
+        int d[2];
+    };
+
     int a = 10;
     int b = 20;
     for (int i = 0; i < 10; i++)
@@ -184,6 +189,8 @@ void vars()
         for (int j = 0; j < 5; ++j)
             array_struct[j] = { i*2 + j, (char)('a'+ j), (float)j};
         Struct* array_struct_p = array_struct;
+
+        Synth synth = {{5, 8}};
 
         const char *cstr = "The quick brown fox";
         const wchar_t *wcstr = L"The quick brown fox";

--- a/debuggee/lldbinit.py
+++ b/debuggee/lldbinit.py
@@ -1,0 +1,46 @@
+import lldb
+
+class TestSynthProvider:
+    """Synthetic provider that generates 4 children from struct containing 2-item array
+    """
+    names = ['first', 'second', 'third', 'forth']
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def num_children(self):
+        return len(self.names)
+
+    def get_child_index(self, name):
+        try:
+            return self.names.index(name)
+        except:
+            return -1
+
+    def get_child_at_index(self, index):
+        try:
+            value = self.valobj.GetChildMemberWithName('d').GetChildAtIndex(index % 2)
+            return self.valobj.CreateValueFromData(self.names[index], value.GetData(), value.GetType())
+
+        except Exception as e:
+            print(e)
+        return None
+
+
+    def update(self):
+        pass
+
+def __lldb_init_module(debugger: lldb.SBDebugger, internal_dict):
+    try:
+        # Use type summary with synthetic formatter together
+        debugger.GetDefaultCategory().AddTypeSummary(
+            lldb.SBTypeNameSpecifier("Synth"),
+            lldb.SBTypeSummary.CreateWithSummaryString("test size=${svar%#}", lldb.eTypeOptionHideValue),
+        )
+        debugger.HandleCommand(
+            'type synthetic add Synth -l ' + __name__ + '.TestSynthProvider'
+        )
+        print("Initialized test LLDB synth provider")
+
+    except Exception as e:
+        print("Failed to initialize Initialized test LLDB synth provider: " + str(e))


### PR DESCRIPTION
Align the logic of showing variable children with LLDB ObjectPrinter ([link](https://github.com/llvm/llvm-project/blob/d480f968ad8b56d3ee4a6b6df5532d485b0ad01e/lldb/source/DataFormatters/ValueObjectPrinter.cpp#L531) to the interesting line) used by "frame variable" command.
When type summary formatter is enabled, children should be hidden by default.
This can be overriden by not using lldb.eTypeOptionHideChildren so type summary can be used with synthetic provider as well (used for default STL providers inside LLDB).

Before - default Linux libstdc++ formatters bundled in LLDB:
![before](https://user-images.githubusercontent.com/31508196/123714128-08c80980-d876-11eb-9dd8-b910aecb6ee4.png)

After:
![after](https://user-images.githubusercontent.com/31508196/123714138-0c5b9080-d876-11eb-9a00-0b8e0b32e72e.png)

Makes easier debugging easier as you can spot easier that there is no reason to open the variable.
