### PR TITLE
Create target when attaching if program is specified

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -744,7 +744,10 @@ impl DebugSession {
             bail!(as_user_error(r#"Either "program" or "pid" is required for attach."#));
         }
 
-        self.target = Initialized(self.debugger.create_target("", None, None, false)?);
+        self.target = match &args.program {
+            Some(program) => Initialized(self.create_target_from_program(program)?),
+            None => Initialized(self.debugger.create_target("", None, None, false)?),
+        };
         self.disassembly = Initialized(disassembly::AddressSpace::new(&self.target));
         self.send_event(EventBody::initialized);
 


### PR DESCRIPTION
Fixes #482 

If `program` is specified in an `attach` config, create target for that before attaching. This is useful in remote debugging cases, and doesn't hurt for local debugging as attaching without the target will create the target in the attach flow anyway if not already created.