### PR TITLE
Add overrideCargo to CargoConfig

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -602,6 +602,7 @@ to use this feature, replace `program` property in your launch configuration wit
     "type": "lldb",
     "request": "launch",
     "cargo": {
+        // "overrideCargo": "mold -run cargo", Command to be executed instead of 'cargo'.
         "args": ["test", "--no-run", "--lib"], // Cargo command line to build the debug target
         // "args": ["build", "--bin=foo"] is another possibility
         "filter": { // Filter applied to compilation artifacts (optional)

--- a/debuggee/.vscode/launch.json
+++ b/debuggee/.vscode/launch.json
@@ -208,6 +208,25 @@
 			"sourceLanguages": [
 				"rust"
 			]
-		}
+		},
+		{
+			"name": "cargo override",
+			"type": "lldb",
+			"request": "launch",
+			"cargo": {
+				"args": [
+					"build",
+					"--bin=rust-debuggee",
+					"--package=rust-debuggee"
+				],
+				"filter": {
+					"name": "rust-debuggee",
+					"kind": "bin"
+				},
+				"overrideCargo": "./wrapper.sh cargo"
+			},
+			"args": [],
+			"cwd": "${workspaceFolder}"
+		},
 	]
 }

--- a/debuggee/wrapper.sh
+++ b/debuggee/wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Hello, this is a wrapper!" 1>&2
+echo "I will run the following commands: $@" 1>&2
+exec $@


### PR DESCRIPTION
Add `overrideCargo` to CargoConfig.

This option allows user to replace `cargo` command with something else (well, something that is compatible with the cargo arguments).

Motivation is that some projects may have wrappers around cargo (or even whole alternatives to cargo), which do something related to the project, and only then run `cargo`. With this feature, such users will be able to use lens and run debug things directly from the IDE rather than from terminal.


This is also available in [rust-analyzer/rust-analyzer](https://github.com/rust-analyzer/rust-analyzer), and this implemention and idea has been ported from https://github.com/rust-analyzer/rust-analyzer/pull/5954