### PR TITLE
RFC/WIP: Support DAP disassemble request

### DIFF
--- a/adapter/src/debug_protocol.rs
+++ b/adapter/src/debug_protocol.rs
@@ -7,7 +7,8 @@ pub use raw_debug_protocol::{
     Breakpoint, BreakpointEventBody, CancelArguments, Capabilities, CapabilitiesEventBody, CompletionItem,
     CompletionsArguments, CompletionsResponseBody, ContinueArguments, ContinueResponseBody, ContinuedEventBody,
     DataBreakpoint, DataBreakpointAccessType, DataBreakpointInfoArguments, DataBreakpointInfoResponseBody,
-    DisconnectArguments, EvaluateArguments, EvaluateResponseBody, ExceptionBreakpointsFilter, ExitedEventBody,
+    DisassembleArguments, DisassembleResponseBody, DisassembledInstruction, DisconnectArguments, EvaluateArguments,
+    EvaluateResponseBody, ExceptionBreakpointsFilter, ExitedEventBody,
     GotoArguments, GotoTarget, GotoTargetsArguments, GotoTargetsResponseBody, InitializeRequestArguments,
     InvalidatedAreas, InvalidatedEventBody, Module, ModuleEventBody, NextArguments, OutputEventBody, PauseArguments,
     ReadMemoryArguments, ReadMemoryResponseBody, RestartFrameArguments, ReverseContinueArguments,
@@ -112,6 +113,7 @@ pub enum RequestArguments {
     readMemory(ReadMemoryArguments),
     terminate(Option<TerminateArguments>),
     disconnect(Option<DisconnectArguments>),
+    disassemble(DisassembleArguments),
     // Reverse
     runInTerminal(RunInTerminalRequestArguments),
     // Custom
@@ -155,6 +157,7 @@ pub enum ResponseBody {
     readMemory(ReadMemoryResponseBody),
     terminate,
     disconnect,
+    disassemble(DisassembleResponseBody),
     // Reverse
     runInTerminal(RunInTerminalResponseBody),
     // Custom

--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -1096,6 +1096,8 @@ impl DebugSession {
                     ..Default::default()
                 });
                 stack_frame.presentation_hint = Some("subtle".to_owned());
+                stack_frame.instruction_pointer_reference =
+                  Some(format!("0x{:X}", pc_addr ));
             }
             stack_frames.push(stack_frame);
         }


### PR DESCRIPTION
Opening this up as a 'request for comments'.  I had a quick go at implementing the [dap disassemble request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disassemble) in CodeLLDB as I wanted something reliable to [test Vimspector's disassemble view with](https://github.com/puremourning/vimspector/issues/510).

Clearly this is a prototype. Would you be interested in a proper patch to support the DAP disassemble request?

---

CodeLLDB currently suppports a custom disassembly view and provides
disassembly as "source" when debugging into objects with no sourceline
info.

DAP now also has a `disassemble` request which, given a memory refernce
from the stack trace, produces a set number of instructions from that
address.

This is simple to implement based on the existing DisassembledRange.

WIP.
 - we don't return the exact number of instructions
 - we don't populate a lot of the optional fields
 - my-first-rust(TM)
 - no tests yet