### PR TITLE
Add Support for Debugging Jai

### DIFF
--- a/package.json
+++ b/package.json
@@ -513,6 +513,9 @@
 				"language": "haskell"
 			},
 			{
+				"language": "jai"
+			},
+			{
 				"language": "java"
 			},
 			{
@@ -571,6 +574,7 @@
 					"crystal",
 					"fortran-modern",
 					"fortran",
+					"jai",
 					"nim",
 					"objective-c",
 					"objective-cpp",


### PR DESCRIPTION
This adds support for debugging [jai](https://github.com/BSVino/JaiPrimer/blob/master/JaiPrimer.md). Jai is a new C/C++ like language, and this is all that I needed to add to get support for it going in VS Code using your extension. Thanks for making it so straightforward! Would love to get this merged so I can switch back to the mainline version of this extension.

- Jim

```
$ dwarfdump tests | head -14

.debug_info

COMPILE_UNIT<header overall offset = 0x00000000>:
< 0><0x0000000b>  DW_TAG_compile_unit
                    DW_AT_producer              Thekla, inc. Jai Compiler
                    DW_AT_language              DW_LANG_C
                    DW_AT_name                  /home/jcalabro/go/src/github.com/jcalabro/jdb/.build/tests_0_w2_996d.obj
                    DW_AT_stmt_list             0x00000000
                    DW_AT_comp_dir              /home/jcalabro/go/src/github.com/jcalabro/jdb
                    DW_AT_GNU_pubnames          yes(1)
                    DW_AT_low_pc                0x002208d0
                    DW_AT_high_pc               <offset-from-lowpc> 27487 <highpc: 0x0022742f>
```

![image](https://user-images.githubusercontent.com/8205547/201501225-0b343253-8b64-4c53-be01-93d8d43860b2.png)
