### PR TITLE
package.json: Support the "arm64" assembly language identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,6 +489,9 @@
 				"language": "arm"
 			},
 			{
+				"language": "arm64"
+			},
+			{
 				"language": "asm"
 			},
 			{
@@ -568,6 +571,7 @@
 				"languages": [
 					"ada",
 					"arm",
+					"arm64",
 					"asm",
 					"c",
 					"cpp",


### PR DESCRIPTION
VSCode does not provide recommendations on language identifiers for assembly source files:
https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers Most likely because there isn't "one" assembly.

Unfortunately this leads to a funny situation where every extension dealing with assembly files can assign its own identifier to '.S' files. As a workaround, CodeLLDB already has to support both the "asm" and "arm" language identifiers which are both valid language identifiers for arm assembly files.

I use the MKornelsen.vscode-arm64 extension, which provides syntax highlighting for arm64 opcodes in assembly files. This extension is implemented by assigning the "arm64" language identifier to .S files. https://github.com/MKornelsen/vscode-arm64/blob/main/package.json#L33

Unfortunately, I also like to set breakpoints in my assembly files and because CodeLLDB does not manifest its understanding of this language id, I have to choose between either using CodeLLDB *or* the arm64 extension.

With this PR, I can use both at the same time.