### PR TITLE
add getCargoLaunchConfigsFromCustomFolder command

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,11 @@
 			},
 			{
 				"category": "LLDB",
+				"title": "Generate Launch Configurations from Custom Cargo.toml",
+				"command": "lldb.getCargoLaunchConfigsFromCustomFolder"
+			},
+			{
+				"category": "LLDB",
 				"title": "Display Options...",
 				"command": "lldb.changeDisplaySettings"
 			},


### PR DESCRIPTION
Allows generating launch.json from other Cargo.toml files other than the one in the root of the workspace