### PR TITLE
fixed #1012 (Displays Garbled on Windows)

### DIFF
--- a/adapter/codelldb/src/terminal.rs
+++ b/adapter/codelldb/src/terminal.rs
@@ -99,6 +99,9 @@ impl Terminal {
             let pid = self.data.parse::<u32>().unwrap();
             winapi::um::wincon::FreeConsole();
             winapi::um::wincon::AttachConsole(pid);
+            // change console code page (text-encoding) to UTF8.
+            winapi::um::wincon::SetConsoleCP(65001);
+            winapi::um::wincon::SetConsoleOutputCP(65001);
         }
     }
 


### PR DESCRIPTION
It looks like all communications with `dap` are encoded in `UTF-8`, so the easiest solution is to change the terminal encoding to UTF-8 as well, I think.

I released a patch for testing it: https://github.com/zhengxiaoyao0716/codelldb/releases