### PR TITLE
Fix timeout error after inactivity in codelldb-launch on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "socket2",
  "termios",
  "winapi",
 ]
@@ -1135,12 +1136,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src/codelldb-launch/Cargo.toml
+++ b/src/codelldb-launch/Cargo.toml
@@ -16,3 +16,4 @@ termios = "0.3.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3.8", features = ["std", "wincon"]}
+socket2 = "0.6.1"


### PR DESCRIPTION
Closes #1337 

After a period of inactivity, Windows will close an inactive TCP connection. When the DAP client (VSCode, Zed, etc.) starts a debugging session, hits a breakpoint, and remains idle for too long, the OS will close the socket opened in `codelldb-launch` effectively rendering that debugging session unusable (no way to continue, etc.). To prevent this, we explicitly set explicit TCP keepalive probes with default interval of 30 seconds.