### PR TITLE
Add automatic RPC configuration

### DIFF
--- a/extension/configUtils.ts
+++ b/extension/configUtils.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 import * as async from './novsc/async';
 import { Dict } from './novsc/commonTypes';
 import { expandVariablesInObject } from './novsc/expand';
+import { ListenOptions } from 'net';
 
 // Expands variable references of the form ${dbgconfig:name} in all properties of launch configuration.
 export function expandDbgConfig(debugConfig: DebugConfiguration, dbgconfigConfig: WorkspaceConfiguration): DebugConfiguration {
@@ -88,3 +89,4 @@ export async function getLLDBDirectories(executable: string): Promise<LLDBDirect
     }
 }
 
+export type RpcConfig = ListenOptions & { token?: string };

--- a/extension/externalLaunch.ts
+++ b/extension/externalLaunch.ts
@@ -98,9 +98,13 @@ export class RpcServer {
     }
 
     public async listen(options: net.ListenOptions) {
-        return new Promise<net.AddressInfo | string | null>(resolve =>
-            this.inner.listen(options, () => resolve(this.inner.address()))
-        );
+        return new Promise<net.AddressInfo | string | null>((resolve, reject) => {
+            try {
+                this.inner.listen(options, () => resolve(this.inner.address()));
+            } catch (error) {
+                reject(error);
+            }
+        });
     }
 
     public close() {

--- a/package.json
+++ b/package.json
@@ -523,9 +523,18 @@
 					},
 					"lldb.rpcServer": {
 						"description": "Start an RPC server that will accept debug configuration requests.",
-						"type": [
-							"object",
-							"null"
+						"anyOf": [
+							{
+								"type": [
+									"object",
+									"string",
+									"null"
+								]
+							},
+							{
+								"const": "auto",
+								"description": "Automatically determine connection details and expose them to the integrated terminal."
+							}
 						],
 						"default": null,
 						"defaultSnippets": [


### PR DESCRIPTION
This PR makes the extension expose the RPC server connection details & client `PATH` to the VS Code integrated terminal via environment variables. It also adds the option to specify `"lldb.rpcServer": "auto"` in settings, which will choose a token and port for the user.

With these changes, launching a debugger from the terminal is much simpler. Users can just set this in their VS Code settings:

```json
{
    "lldb.rpcServer": "auto"
}
```

Then use the `codelldb-launch` command, which is automatically added to their PATH:

```terminal
$ codelldb-launch target/debug/hello-world
Hello world!
```

Resolves #1348.